### PR TITLE
Remove unnecessary task bar hide during full screen - easier debugging...

### DIFF
--- a/crt.h
+++ b/crt.h
@@ -1101,14 +1101,16 @@ static bool is_handle_valid(void* h) {
 
 static bool threads_try_join(thread_t t, double timeout) {
     not_null(t);
-    fatal_if_false(is_handle_valid(t));
-    int32_t timeout_ms = timeout <= 0 ? 0 : (int)(timeout * 1000.0 + 0.5);
-    int r = WaitForSingleObject(t, timeout_ms);
-    if (r != 0) {
-        traceln("failed to join thread %p %s", t, crt.error(r));
-    } else {
-        r = CloseHandle(t) ? 0 : GetLastError();
-        if (r != 0) { traceln("CloseHandle(%p) failed %s", t, crt.error(r)); }
+    int r = 0;
+    if (is_handle_valid(t)) {
+        int32_t timeout_ms = timeout <= 0 ? 0 : (int)(timeout * 1000.0 + 0.5);
+        r = WaitForSingleObject(t, timeout_ms);
+        if (r != 0) {
+            traceln("failed to join thread %p %s", t, crt.error(r));
+        } else {
+            r = CloseHandle(t) ? 0 : GetLastError();
+            if (r != 0) { traceln("CloseHandle(%p) failed %s", t, crt.error(r)); }
+        }
     }
     return r == 0;
 }

--- a/quick.h
+++ b/quick.h
@@ -4143,7 +4143,6 @@ static void app_full_screen(bool on) {
     static int32_t style;
     static WINDOWPLACEMENT wp;
     if (on != app.is_full_screen) {
-        app_show_task_bar(!on);
         if (on) {
             style = GetWindowLongA(window(), GWL_STYLE);
             app_set_window_long(GWL_STYLE, (style | WS_POPUP | WS_VISIBLE) &


### PR DESCRIPTION
With WS_POPUP style full-screen window covers task bar and it doesn't need hiding. However, if task bar is hidden and app crashes (or is terminated by debugger), bringing it back is a bit of a chore. This change leaves task bar as-is so it stays visible after crash or shift-F5.